### PR TITLE
Refactor Pydantic models to use json_schema_extra and add translation maps for common and property overviews

### DIFF
--- a/app/models/common_overview.py
+++ b/app/models/common_overview.py
@@ -43,7 +43,7 @@ class CommonOverview(BaseModel):
     property_id: PyObjectId = Field(..., title="the id of the property")
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "所在地": "東京都目黒区駒場１",
                 "交通": [
@@ -63,3 +63,15 @@ class CommonOverview(BaseModel):
                 "property_id": "6790f0aa68873b21a872d2a7",
             }
         }
+
+
+COMMON_OVERVIEW_TRANSLATION_MAP = {
+    "所在地": "location",
+    "交通": "transportation",
+    "総戸数": "total_units",
+    "構造・階建て": "structure_floors",
+    "敷地面積": "site_area",
+    "敷地の権利形態": "site_ownership_type",
+    "用途地域": "usage_area",
+    "駐車場": "parking_lot",
+}

--- a/app/models/property.py
+++ b/app/models/property.py
@@ -23,7 +23,7 @@ class Property(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "name": "クレヴィア渋谷富ヶ谷",
                 "url": "https://suumo.jp/ms/chuko/tokyo/sc_shibuya/nc_76483805/",

--- a/app/models/property_overview.py
+++ b/app/models/property_overview.py
@@ -45,8 +45,16 @@ class PropertyOverview(BaseModel):
     最多価格帯: str = Field(..., title="the highest price range")
     価格: str = Field(..., title="the price of the property")
     管理費: str = Field(..., title="the management fee of the property")
-    修繕積立金: str = Field(..., title="the repair reserve fund of the property")
-    修繕積立基金: str = Field(..., title="the repair reserve fund of the property")
+    # The difference between 修繕積立金 and 修繕積立基金 is explained in https://suumo.jp/article/oyakudachi/oyaku/ms_shinchiku/ms_money/ms_shuzentsumitatekikin/
+    # 修繕積立金: 建物の外壁やエントランス、屋上などの共用部分を維持し、修繕するために行われる「大規模修繕」などに必要な資金
+    # 修繕積立基金: 第一回の大規模修繕工事に充てるためのお金
+    修繕積立金: str = Field(
+        ...,
+        title="the fund required for “major repairs” and other necessary repairs to maintain and repair common areas such as building exterior walls, entrances, rooftops, etc.",
+    )
+    修繕積立基金: str = Field(
+        ..., title="the money to be used for the first major repair work"
+    )
     諸費用: str = Field(..., title="the other expenses of the property")
     間取り: str = Field(..., title="the floor plan of the property")
     専有面積: str = Field(..., title="the area of the property")
@@ -85,7 +93,7 @@ class PropertyOverview(BaseModel):
     property_id: PyObjectId = Field(..., title="the id of the property")
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "販売スケジュール": "-",
                 "イベント情報": "-",
@@ -114,3 +122,29 @@ class PropertyOverview(BaseModel):
                 "property_id": "6790f0aa68873b21a872d2a7",
             }
         }
+
+
+PROPERTY_OVERVIEW_TRANSLATION_MAP = {
+    "販売スケジュール": "sales_schedule",
+    "イベント情報": "event_information",
+    "販売戸数": "number_of_units_for_sale",
+    "最多価格帯": "highest_price_range",
+    "価格": "price",
+    "管理費": "maintenance_fee",
+    "修繕積立金": "repair_reserve_fund",
+    "修繕積立基金": "first_repair_reserve_fund",
+    "諸費用": "other_expenses",
+    "間取り": "floor_plan",
+    "専有面積": "area",
+    "その他面積": "other_area",
+    "引渡可能時期": "delivery_time",
+    "完成時期(築年月)": "completion_time",
+    "所在階": "floor",
+    "向き": "direction",
+    "エネルギー消費性能": "energy_consumption_performance",
+    "断熱性能": "insulation_performance",
+    "目安光熱費": "estimated_utility_cost",
+    "リフォーム": "renovation",
+    "その他制限事項": "other_restrictions",
+    "その他概要・特記事項": "other_overview_and_special_notes",
+}

--- a/app/services/utils.py
+++ b/app/services/utils.py
@@ -10,3 +10,11 @@ def to_json_serializable(doc):
     if isinstance(doc, ObjectId):
         return str(doc)
     return doc
+
+
+def translate_keys(data: dict, translation_map: dict) -> dict:
+    translated_data = {}
+    for key, value in data.items():
+        translated_key = translation_map.get(key, key)
+        translated_data[translated_key] = value
+    return translated_data

--- a/mansion_watch_scraper/spiders/suumo_scraper.py
+++ b/mansion_watch_scraper/spiders/suumo_scraper.py
@@ -2,7 +2,10 @@ import scrapy
 from scrapy.spidermiddlewares.httperror import HttpError
 from twisted.internet.error import DNSLookupError, TCPTimedOutError, TimeoutError
 
+from app.models.common_overview import COMMON_OVERVIEW_TRANSLATION_MAP
+from app.models.property_overview import PROPERTY_OVERVIEW_TRANSLATION_MAP
 from app.services.dates import get_current_time
+from app.services.utils import translate_keys
 from enums.html_element_keys import ElementKeys
 
 
@@ -58,6 +61,11 @@ class MansionWatchSpider(scrapy.Spider):
             "updated_at": get_current_time(),
         }
 
+        # 物件画像
+        # property_image_xpath = '//*[@id="js-lightbox"]/li/div/a/@data-src'
+        # image_urls = response.xpath(property_image_xpath).getall()
+        # property_dict["image_urls"] = image_urls
+
         # 物件概要
         # Use this type of xpath to get the target element because the number of elements often changes.
         property_overview_xpath = f'//div[@class="secTitleOuterR"]/h3[@class="secTitleInnerR" and contains(text(), "{property_name + ElementKeys.APERTMENT_SUFFIX.value}")]/ancestor::div[@class="secTitleOuterR"]/following-sibling::table/tbody/tr'
@@ -73,6 +81,9 @@ class MansionWatchSpider(scrapy.Spider):
 
             for key, value in zip(normalized_keys, normalized_values):
                 property_overview_dict[key] = value
+        property_overview_dict = translate_keys(
+            property_overview_dict, PROPERTY_OVERVIEW_TRANSLATION_MAP
+        )
         property_overview_dict["created_at"] = get_current_time()
         property_overview_dict["updated_at"] = get_current_time()
 
@@ -94,6 +105,9 @@ class MansionWatchSpider(scrapy.Spider):
                     common_overview_dict[key] = normalized_values
                 else:
                     common_overview_dict[key] = value
+        common_overview_dict = translate_keys(
+            common_overview_dict, COMMON_OVERVIEW_TRANSLATION_MAP
+        )
         common_overview_dict["created_at"] = get_current_time()
         common_overview_dict["updated_at"] = get_current_time()
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of property data and translations in the codebase. The most important changes include modifying schema configurations, adding translation maps, and updating the scraper to use these translations.

### Schema Configuration Changes:
* Changed `schema_extra` to `json_schema_extra` in the `Config` class of `common_overview.py`, `property.py`, and `property_overview.py` to align with the new naming convention. [[1]](diffhunk://#diff-ac4b2f2478fc215f7e34ebcd67ff74601169de21373f510ff08aff246dc06e2dL46-R46) [[2]](diffhunk://#diff-a11042ad6408305cd09ec5598903b743c6625c4b40d1b6b10e2ddcc4ac529444L26-R26) [[3]](diffhunk://#diff-859daf7e710c6bd4335311e688f9828ed27aca9eaf8c60f6c4eaaa4ce6ac752cL88-R96)

### Translation Maps:
* Added `COMMON_OVERVIEW_TRANSLATION_MAP` to `common_overview.py` for translating property overview fields from Japanese to English.
* Added `PROPERTY_OVERVIEW_TRANSLATION_MAP` to `property_overview.py` for translating property fields from Japanese to English.

### Scraper Updates:
* Updated `suumo_scraper.py` to import the newly added translation maps and the `translate_keys` function.
* Modified the `parse` method in `suumo_scraper.py` to use `translate_keys` with the corresponding translation maps for `property_overview_dict` and `common_overview_dict`. [[1]](diffhunk://#diff-4b5084eed43e17b8687226082e1c4c0231aa15f17b08b674d550bf2edf62d150R84-R86) [[2]](diffhunk://#diff-4b5084eed43e17b8687226082e1c4c0231aa15f17b08b674d550bf2edf62d150R108-R110)

### Utility Function:
* Added a `translate_keys` function in `utils.py` to facilitate the translation of dictionary keys based on a provided translation map.

### Documentation:
* Enhanced documentation for `修繕積立金` and `修繕積立基金` fields in `property_overview.py` to provide detailed explanations of their differences.