### PR TITLE
Enhance GCS image upload and download error handling

### DIFF
--- a/mansion_watch_scraper/pipelines.py
+++ b/mansion_watch_scraper/pipelines.py
@@ -430,7 +430,7 @@ def get_gcs_url(bucket_name: str, blob_name: str) -> str:
         blob_name: Name of the blob
 
     Returns:
-        Public URL string
+        Public HTTPS URL string for accessing the blob
     """
     return f"https://storage.googleapis.com/{bucket_name}/{blob_name}"
 

--- a/tests/unit/scraper/pipelines/test_image_pipeline.py
+++ b/tests/unit/scraper/pipelines/test_image_pipeline.py
@@ -113,7 +113,7 @@ class TestImagePipeline(unittest.TestCase):
         result = get_gcs_url("test-bucket", "test-blob")
 
         # Assert that the result is correct
-        self.assertEqual(result, "gs://test-bucket/test-blob")
+        self.assertEqual(result, "https://storage.googleapis.com/test-bucket/test-blob")
 
     @patch("mansion_watch_scraper.pipelines.check_blob_exists")
     def test_process_image_urls_with_gcs_check_chunked_logging(


### PR DESCRIPTION
- Add public URL generation function for GCS blobs
- Modify image upload to set public-read ACL
- Implement robust retry mechanism for image downloads
- Improve error logging and handling in SuumoImagesPipeline
- Increase download timeout and add configurable retry attempts